### PR TITLE
feat: get_vk binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-vk"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "sp1-sdk",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "crates/*",
+    "crates/*", "get-vk",
     "native-host",
     "validity-client",
     "zkvm-client",

--- a/get-vk/Cargo.toml
+++ b/get-vk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "get-vk"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+clap = { workspace = true }
+sp1-sdk = { workspace = true }

--- a/get-vk/src/main.rs
+++ b/get-vk/src/main.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+use sp1_sdk::{HashableKey, ProverClient};
+use std::{fs::File, io::Read};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The ELF file to get the VK for.
+    #[arg(short, long)]
+    elf: String,
+}
+
+/// Get the verification key for a given program.
+fn main() {
+    let args = Args::parse();
+
+    // Read the elf file contents into a Vec<u8>
+    let mut file = File::open(format!("elf/{}", args.elf)).unwrap();
+    let mut elf_contents = Vec::new();
+    file.read_to_end(&mut elf_contents).unwrap();
+
+    let prover = ProverClient::new();
+    let (_, vk) = prover.setup(&elf_contents);
+    println!("{:?}", vk.vk.bytes32());
+}

--- a/justfile
+++ b/justfile
@@ -22,6 +22,10 @@ run-multi start end verbosity="0" use-cache="false":
   fi
   cargo run --bin multi --release -- --start {{start}} --end {{end}} --verbosity {{verbosity}} $CACHE_FLAG
 
+get-vk elf_name:
+    #!/usr/bin/env bash
+    cargo run --bin get-vk --release -- --elf {{elf_name}}
+
 # Runs the client program in native execution mode. Modified version of Kona Native Client execution:
 # https://github.com/ethereum-optimism/kona/blob/ae71b9df103c941c06b0dc5400223c4f13fe5717/bin/client/justfile#L65-L108
 run-client-native l2_block_num l1_rpc='${CLABBY_RPC_L1}' l1_beacon_rpc='${ETH_BEACON_URL}' l2_rpc='${CLABBY_RPC_L2}' verbosity="-vvvv":
@@ -72,6 +76,6 @@ run-client-native l2_block_num l1_rpc='${CLABBY_RPC_L1}' l1_beacon_rpc='${ETH_BE
     --exec $CLIENT_BIN_PATH \
     --data-dir $DATA_DIRECTORY \
     {{verbosity}}
-  
+
   # Output the data required for the ZKVM execution.
   echo "$L1_HEAD $L2_OUTPUT_ROOT $L2_CLAIM $L2_BLOCK_NUMBER $L2_CHAIN_ID"


### PR DESCRIPTION
When deploying a new chain, we'll want to ensure that the VK used on the chain matches the program we're using. This binary will be added to the deployment process to generate the VK from the ELF and include it in the chain's config.