### PR TITLE
feat: add statistics tracker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # 
-CLABBY_RPC_L1=
+L1_RPC=
 # L1 Consensus RPC
-ETH_BEACON_URL=
+L1_BEACON_RPC=
 # L2 Archive Node (OP-Geth)
-CLABBY_RPC_L2=
+L2_RPC=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5759,8 +5759,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9c5c2628b485693b6c2e5ba89f1af7ce5cfede39a6a4b041afd2e5b838480"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5771,8 +5770,7 @@ dependencies = [
 [[package]]
 name = "sp1-core"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e81b0fa73362b0b2cffa420999f80f72f7f30d41c2412d207625b5253cdf89"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -5834,8 +5832,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57c1fb4429a70191bc8b70c57e35ee876a8e4eff4719b4956fd325a48b6bbe"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5845,8 +5842,7 @@ dependencies = [
 [[package]]
 name = "sp1-helper"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6177089127a447ea26b258f722050c0c4f874eba5df7934b246b59088c8f72"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "cargo_metadata",
  "chrono",
@@ -5868,8 +5864,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2996170e381b301bc3debcb1cbb93614e26b912a87eca511992087be645b7e6b"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "itertools 0.13.0",
  "lazy_static",
@@ -5882,8 +5877,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544aeed08f56e7c84442dcd1a4038e31b2918b36c0738f11bc125353640aa5b1"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5920,8 +5914,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12d638aa351786256c31c5979f10ee6118eeb4df1935cfa67ae2da6b1b3eeb9"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "bincode",
  "itertools 0.13.0",
@@ -5944,8 +5937,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818c9ba6b49ef9740665486fcc3871248068bf3cb8045f2a7f3aff3c8ba5dfdb"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -5970,8 +5962,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-core"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa8990611d0afc957f79c3c7f8f16403fed32cc9cac1006284ac443eafa5341"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "arrayref",
  "backtrace",
@@ -6006,8 +5997,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-derive"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2b271ae555360b5db81bd97f32b023d996064c99dc840b5f7376f231ee30de"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6017,8 +6007,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e631ce29e7b49b363cb60717f514e652390602423f063bd0ff0c11e8d23a500"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6043,8 +6032,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-program"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae721d563ad3faf11f0503b64b349dba5222113a7b49c5c0aebfdcd7bc00a4b"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -6073,8 +6061,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e3d66fd2b5874bb5b7bce7be8a84c9d496ea5546b3b85a754ac6a9ab9927d5"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=dev#bfe97844d5b813b949be46819bbd58a9ee89fb81"
 dependencies = [
  "alloy-sol-types",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,11 @@ op-alloy-consensus = { version = "0.1", default-features = false }
 num-format = "0.4.4"
 bincode = "1.3.3"
 
-# Note: Using `dev` branch temporarily for the cycle-tracker-report features.
 sp1-lib = "1.1.0"
 sp1-zkvm = "1.1.0"
 # sp1-sdk = "1.1.0"
+# sp1-helper = "1.1.0"
+# Note: Using `dev` branch temporarily for the cycle-tracker-report features.
 sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", branch = "dev" }
 sp1-helper = { git = "https://github.com/succinctlabs/sp1.git", branch = "dev" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,12 @@ op-alloy-consensus = { version = "0.1", default-features = false }
 num-format = "0.4.4"
 bincode = "1.3.3"
 
+# Note: Using `dev` branch temporarily for the cycle-tracker-report features.
 sp1-lib = "1.1.0"
 sp1-zkvm = "1.1.0"
-sp1-sdk = "1.1.0"
-sp1-helper = "1.1.0"
+# sp1-sdk = "1.1.0"
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", branch = "dev" }
+sp1-helper = { git = "https://github.com/succinctlabs/sp1.git", branch = "dev" }
 
 # sp1
 [profile.release-client-lto]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ just run-multi <start> <end> [use-cache] [prove]
 
 - [use-cache]: Optional flag to re-use the native execution cache (default: false).
 - [prove]: Optional flag to prove the execution (default: false).
+- [stats]: Optional flag to print out the statistics (default: false).
 
 Observations: 
 * For most blocks, the cycle count per transaction is around 4M cycles per transaction.
-* TODO: Do further analysis on the cycle count.
+* Some example cycle count estimates can be found [here](https://www.notion.so/succinctlabs/SP1-Kona-8b025f81f28f4d149eb4816db4e6d80b?pvs=4).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ just run-multi <start> <end> [use-cache] [prove]
 
 - [use-cache]: Optional flag to re-use the native execution cache (default: false).
 - [prove]: Optional flag to prove the execution (default: false).
-- [stats]: Optional flag to print out the statistics (default: false).
 
 Observations: 
 * For most blocks, the cycle count per transaction is around 4M cycles per transaction.

--- a/crates/host-utils/src/fetcher.rs
+++ b/crates/host-utils/src/fetcher.rs
@@ -30,12 +30,10 @@ impl Default for SP1KonaDataFetcher {
 impl SP1KonaDataFetcher {
     pub fn new() -> Self {
         SP1KonaDataFetcher {
-            l1_rpc: env::var("CLABBY_RPC_L1")
-                .unwrap_or_else(|_| "http://localhost:8545".to_string()),
-            l1_beacon_rpc: env::var("ETH_BEACON_URL")
+            l1_rpc: env::var("L1_RPC").unwrap_or_else(|_| "http://localhost:8545".to_string()),
+            l1_beacon_rpc: env::var("L1_BEACON_RPC")
                 .unwrap_or_else(|_| "http://localhost:5052".to_string()),
-            l2_rpc: env::var("CLABBY_RPC_L2")
-                .unwrap_or_else(|_| "http://localhost:9545".to_string()),
+            l2_rpc: env::var("L2_RPC").unwrap_or_else(|_| "http://localhost:9545".to_string()),
         }
     }
 

--- a/crates/host-utils/src/fetcher.rs
+++ b/crates/host-utils/src/fetcher.rs
@@ -37,6 +37,22 @@ impl SP1KonaDataFetcher {
         }
     }
 
+    // Get the number of transactions in a single block.
+    pub async fn get_block_transaction_count(rpc: &str, block_number: u64) -> Result<u64> {
+        let l2_provider = Provider::<Http>::try_from(rpc)?;
+        let block = l2_provider.get_block(block_number).await?.unwrap();
+        Ok(block.transactions.len() as u64)
+    }
+
+    // Get the number of transactions in a range of blocks inclusive.
+    pub async fn get_block_transaction_count_range(rpc: &str, start: u64, end: u64) -> Result<u64> {
+        let mut count = 0;
+        for block_number in start..=end {
+            count += Self::get_block_transaction_count(rpc, block_number).await?;
+        }
+        Ok(count)
+    }
+
     async fn find_block_by_timestamp(&self, target_timestamp: U256) -> Result<B256> {
         let l1_provider = Provider::<Http>::try_from(&self.l1_rpc)?;
         let latest_block = l1_provider.get_block(BlockNumber::Latest).await?.unwrap();

--- a/crates/host-utils/src/lib.rs
+++ b/crates/host-utils/src/lib.rs
@@ -54,7 +54,7 @@ pub fn get_sp1_stdin(host_cli: &HostCli) -> Result<SP1Stdin> {
         AlignedSerializer::new(AlignedVec::new()),
         // TODO: This value is hardcoded to minimum for this block.
         // Figure out how to compute it so it works on all blocks.
-        HeapScratch::<8388608>::new(),
+        HeapScratch::<33554432>::new(),
         SharedSerializeMap::new(),
     );
     serializer.serialize_value(&kv_store)?;

--- a/crates/host-utils/src/lib.rs
+++ b/crates/host-utils/src/lib.rs
@@ -52,8 +52,8 @@ pub fn get_sp1_stdin(host_cli: &HostCli) -> Result<SP1Stdin> {
 
     let mut serializer = CompositeSerializer::new(
         AlignedSerializer::new(AlignedVec::new()),
-        // TODO: This value is hardcoded to minimum for this block.
-        // Figure out how to compute it so it works on all blocks.
+        // TODO: This value corresponds to the size of the space needed to
+        // serialize the KV store. We should compute this dynamically.
         HeapScratch::<33554432>::new(),
         SharedSerializeMap::new(),
     );

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ run-multi start end verbosity="0" use-cache="false":
 
 # Runs the client program in native execution mode. Modified version of Kona Native Client execution:
 # https://github.com/ethereum-optimism/kona/blob/ae71b9df103c941c06b0dc5400223c4f13fe5717/bin/client/justfile#L65-L108
-run-client-native l2_block_num l1_rpc='${CLABBY_RPC_L1}' l1_beacon_rpc='${ETH_BEACON_URL}' l2_rpc='${CLABBY_RPC_L2}' verbosity="-vvvv":
+run-client-native l2_block_num l1_rpc='${L1_RPC}' l1_beacon_rpc='${L1_BEACON_RPC}' l2_rpc='${L2_RPC}' verbosity="-vvvv":
   #!/usr/bin/env bash
   L1_NODE_ADDRESS="{{l1_rpc}}"
   L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ run-single l2_block_num use-cache="false":
   cargo run --bin single --release -- --l2-block {{l2_block_num}} $CACHE_FLAG
 
 # Runs the kona-host program for multiple blocks.
-run-multi start end use-cache="false" prove="false" stats="true":
+run-multi start end use-cache="false" prove="false":
   #!/usr/bin/env bash
   CACHE_FLAG=""
   if [ "{{use-cache}}" = "true" ]; then
@@ -24,12 +24,8 @@ run-multi start end use-cache="false" prove="false" stats="true":
   if [ "{{prove}}" = "true" ]; then
     PROVE_FLAG="--prove"
   fi
-  STATS_FLAG=""
-  if [ "{{stats}}" = "true" ]; then
-    STATS_FLAG="--stats"
-  fi
 
-  cargo run --bin multi --release -- --start {{start}} --end {{end}} $CACHE_FLAG $PROVE_FLAG $STATS_FLAG
+  cargo run --bin multi --release -- --start {{start}} --end {{end}} $CACHE_FLAG $PROVE_FLAG
 
 # Runs the client program in native execution mode. Modified version of Kona Native Client execution:
 # https://github.com/ethereum-optimism/kona/blob/ae71b9df103c941c06b0dc5400223c4f13fe5717/bin/client/justfile#L65-L108

--- a/validity-client/src/main.rs
+++ b/validity-client/src/main.rs
@@ -121,11 +121,11 @@ fn main() {
                     "Executing Payload for L2 Block: {}",
                     payload.parent.block_info.number + 1
                 );
-                println!("cycle-tracker-start: execution");
+                println!("cycle-tracker-report-start: block-execution");
                 new_block_header = executor
                     .execute_payload(payload.attributes.clone())
                     .unwrap();
-                println!("cycle-tracker-end: execution");
+                println!("cycle-tracker-report-end: block-execution");
                 let new_block_number = new_block_header.number;
                 assert_eq!(new_block_number, payload.parent.block_info.number + 1);
 

--- a/zkvm-host/bin/multi.rs
+++ b/zkvm-host/bin/multi.rs
@@ -82,6 +82,10 @@ async fn main() -> Result<()> {
     let total_instruction_count = report.total_instruction_count();
 
     if args.stats {
+        // Get the total instruction count for execution across all blocks.
+        let block_execution_instruction_count =
+            report.cycle_tracker.get("block-execution").unwrap();
+
         let nb_blocks = args.end - args.start + 1;
 
         // Fetch the number of transactions in the blocks from the L2 RPC.
@@ -96,6 +100,7 @@ async fn main() -> Result<()> {
             "{}",
             ExecutionStats {
                 total_instruction_count,
+                block_execution_instruction_count,
                 nb_blocks,
                 nb_transactions,
                 total_gas_used,

--- a/zkvm-host/bin/multi.rs
+++ b/zkvm-host/bin/multi.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let data_fetcher = SP1KonaDataFetcher {
-        l2_rpc: env::var("CLABBY_RPC_L2").expect("CLABBY_RPC_L2 is not set."),
+        l2_rpc: env::var("L2_RPC").expect("L2_RPC is not set."),
         ..Default::default()
     };
 

--- a/zkvm-host/bin/multi.rs
+++ b/zkvm-host/bin/multi.rs
@@ -83,8 +83,8 @@ async fn main() -> Result<()> {
 
     if args.stats {
         // Get the total instruction count for execution across all blocks.
-        let block_execution_instruction_count =
-            report.cycle_tracker.get("block-execution").unwrap();
+        let block_execution_instruction_count: u64 =
+            *report.cycle_tracker.get("block-execution").unwrap();
 
         let nb_blocks = args.end - args.start + 1;
 
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             "{}",
             ExecutionStats {
                 total_instruction_count,
-                block_execution_instruction_count: *block_execution_instruction_count,
+                block_execution_instruction_count,
                 nb_blocks,
                 nb_transactions,
                 total_gas_used,

--- a/zkvm-host/bin/multi.rs
+++ b/zkvm-host/bin/multi.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             "{}",
             ExecutionStats {
                 total_instruction_count,
-                block_execution_instruction_count,
+                block_execution_instruction_count: *block_execution_instruction_count,
                 nb_blocks,
                 nb_transactions,
                 total_gas_used,

--- a/zkvm-host/bin/single.rs
+++ b/zkvm-host/bin/single.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     utils::setup_logger();
 
     let data_fetcher = SP1KonaDataFetcher {
-        l2_rpc: env::var("CLABBY_RPC_L2").expect("CLABBY_RPC_L2 is not set."),
+        l2_rpc: env::var("L2_RPC").expect("L2_RPC is not set."),
         ..Default::default()
     };
 

--- a/zkvm-host/src/lib.rs
+++ b/zkvm-host/src/lib.rs
@@ -1,77 +1,10 @@
-use std::fmt;
-
-use num_format::{Locale, ToFormattedString};
 use revm::{
     precompile::Precompiles,
     primitives::{Address, Bytes, Precompile},
 };
 
-/// Statistics for the multi-block execution.
-#[derive(Debug)]
-pub struct ExecutionStats {
-    pub total_instruction_count: u64,
-    pub nb_blocks: u64,
-    pub nb_transactions: u64,
-}
-
-impl fmt::Display for ExecutionStats {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let cycles_per_block = self.total_instruction_count / self.nb_blocks;
-        let cycles_per_transaction = self.total_instruction_count / self.nb_transactions;
-        let transactions_per_block = self.nb_transactions / self.nb_blocks;
-
-        writeln!(
-            f,
-            "+--------------------------------+---------------------------+"
-        )?;
-        writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
-        writeln!(
-            f,
-            "+--------------------------------+---------------------------+"
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Instruction Count",
-            self.total_instruction_count
-                .to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Blocks",
-            self.nb_blocks.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Transactions",
-            self.nb_transactions.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Cycles per Block",
-            cycles_per_block.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Cycles per Transaction",
-            cycles_per_transaction.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Transactions per Block",
-            transactions_per_block.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "+--------------------------------+---------------------------+"
-        )
-    }
-}
+mod utils;
+pub use utils::ExecutionStats;
 
 /// This precompile hook substitutes the precompile with a custom one that can stub out the logic
 /// for specific operations that we don't have precompiles for. Used in `create_hook_precompile`.

--- a/zkvm-host/src/lib.rs
+++ b/zkvm-host/src/lib.rs
@@ -1,7 +1,77 @@
+use std::fmt;
+
+use num_format::{Locale, ToFormattedString};
 use revm::{
     precompile::Precompiles,
     primitives::{Address, Bytes, Precompile},
 };
+
+/// Statistics for the multi-block execution.
+#[derive(Debug)]
+pub struct ExecutionStats {
+    pub total_instruction_count: u64,
+    pub nb_blocks: u64,
+    pub nb_transactions: u64,
+}
+
+impl fmt::Display for ExecutionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cycles_per_block = self.total_instruction_count / self.nb_blocks;
+        let cycles_per_transaction = self.total_instruction_count / self.nb_transactions;
+        let transactions_per_block = self.nb_transactions / self.nb_blocks;
+
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )?;
+        writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Instruction Count",
+            self.total_instruction_count
+                .to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Blocks",
+            self.nb_blocks.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Transactions",
+            self.nb_transactions.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Cycles per Block",
+            cycles_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Cycles per Transaction",
+            cycles_per_transaction.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Transactions per Block",
+            transactions_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )
+    }
+}
 
 /// This precompile hook substitutes the precompile with a custom one that can stub out the logic
 /// for specific operations that we don't have precompiles for. Used in `create_hook_precompile`.

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -12,6 +12,16 @@ pub struct ExecutionStats {
     pub total_gas_used: u64,
 }
 
+/// Write a statistic to the formatter.
+fn write_stat(f: &mut fmt::Formatter<'_>, label: &str, value: u64) -> fmt::Result {
+    writeln!(
+        f,
+        "| {:<30} | {:>25} |",
+        label,
+        value.to_formatted_string(&Locale::en)
+    )
+}
+
 impl fmt::Display for ExecutionStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let cycles_per_block = self.block_execution_instruction_count / self.nb_blocks;
@@ -29,68 +39,20 @@ impl fmt::Display for ExecutionStats {
             f,
             "+--------------------------------+---------------------------+"
         )?;
-        writeln!(
+        write_stat(f, "Total Cycles", self.total_instruction_count)?;
+        write_stat(
             f,
-            "| {:<30} | {:>25} |",
-            "Total Instruction Count",
-            self.total_instruction_count
-                .to_formatted_string(&Locale::en)
+            "Block Execution Cycles",
+            self.block_execution_instruction_count,
         )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Block Execution Instruction Count",
-            self.block_execution_instruction_count
-                .to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Blocks",
-            self.nb_blocks.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Transactions",
-            self.nb_transactions.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Cycles per Block",
-            cycles_per_block.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Cycles per Transaction",
-            cycles_per_transaction.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Transactions per Block",
-            transactions_per_block.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Total Gas Used",
-            self.total_gas_used.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Gas Used per Block",
-            gas_used_per_block.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
-            "Gas Used per Transaction",
-            gas_used_per_transaction.to_formatted_string(&Locale::en)
-        )?;
+        write_stat(f, "Total Blocks", self.nb_blocks)?;
+        write_stat(f, "Total Transactions", self.nb_transactions)?;
+        write_stat(f, "Cycles per Block", cycles_per_block)?;
+        write_stat(f, "Cycles per Transaction", cycles_per_transaction)?;
+        write_stat(f, "Transactions per Block", transactions_per_block)?;
+        write_stat(f, "Total Gas Used", self.total_gas_used)?;
+        write_stat(f, "Gas Used per Block", gas_used_per_block)?;
+        write_stat(f, "Gas Used per Transaction", gas_used_per_transaction)?;
         writeln!(
             f,
             "+--------------------------------+---------------------------+"

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -16,6 +16,8 @@ impl fmt::Display for ExecutionStats {
         let cycles_per_block = self.total_instruction_count / self.nb_blocks;
         let cycles_per_transaction = self.total_instruction_count / self.nb_transactions;
         let transactions_per_block = self.nb_transactions / self.nb_blocks;
+        let gas_used_per_block = self.total_gas_used / self.nb_blocks;
+        let gas_used_per_transaction = self.total_gas_used / self.nb_transactions;
 
         writeln!(
             f,
@@ -48,6 +50,12 @@ impl fmt::Display for ExecutionStats {
         writeln!(
             f,
             "| {:<30} | {:>25} |",
+            "Total Gas Used",
+            self.total_gas_used.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
             "Cycles per Block",
             cycles_per_block.to_formatted_string(&Locale::en)
         )?;
@@ -62,6 +70,18 @@ impl fmt::Display for ExecutionStats {
             "| {:<30} | {:>25} |",
             "Transactions per Block",
             transactions_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Gas Used per Block",
+            gas_used_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Gas Used per Transaction",
+            gas_used_per_transaction.to_formatted_string(&Locale::en)
         )?;
         writeln!(
             f,

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -50,12 +50,6 @@ impl fmt::Display for ExecutionStats {
         writeln!(
             f,
             "| {:<30} | {:>25} |",
-            "Total Gas Used",
-            self.total_gas_used.to_formatted_string(&Locale::en)
-        )?;
-        writeln!(
-            f,
-            "| {:<30} | {:>25} |",
             "Cycles per Block",
             cycles_per_block.to_formatted_string(&Locale::en)
         )?;
@@ -70,6 +64,12 @@ impl fmt::Display for ExecutionStats {
             "| {:<30} | {:>25} |",
             "Transactions per Block",
             transactions_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Gas Used",
+            self.total_gas_used.to_formatted_string(&Locale::en)
         )?;
         writeln!(
             f,

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+
+use num_format::{Locale, ToFormattedString};
+
+/// Statistics for the multi-block execution.
+#[derive(Debug)]
+pub struct ExecutionStats {
+    pub total_instruction_count: u64,
+    pub nb_blocks: u64,
+    pub nb_transactions: u64,
+}
+
+impl fmt::Display for ExecutionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cycles_per_block = self.total_instruction_count / self.nb_blocks;
+        let cycles_per_transaction = self.total_instruction_count / self.nb_transactions;
+        let transactions_per_block = self.nb_transactions / self.nb_blocks;
+
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )?;
+        writeln!(f, "| {:<30} | {:<25} |", "Metric", "Value")?;
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Instruction Count",
+            self.total_instruction_count
+                .to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Blocks",
+            self.nb_blocks.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Total Transactions",
+            self.nb_transactions.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Cycles per Block",
+            cycles_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Cycles per Transaction",
+            cycles_per_transaction.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Transactions per Block",
+            transactions_per_block.to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "+--------------------------------+---------------------------+"
+        )
+    }
+}

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -6,6 +6,7 @@ use num_format::{Locale, ToFormattedString};
 #[derive(Debug)]
 pub struct ExecutionStats {
     pub total_instruction_count: u64,
+    pub block_execution_instruction_count: u64,
     pub nb_blocks: u64,
     pub nb_transactions: u64,
     pub total_gas_used: u64,
@@ -13,8 +14,8 @@ pub struct ExecutionStats {
 
 impl fmt::Display for ExecutionStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let cycles_per_block = self.total_instruction_count / self.nb_blocks;
-        let cycles_per_transaction = self.total_instruction_count / self.nb_transactions;
+        let cycles_per_block = self.block_execution_instruction_count / self.nb_blocks;
+        let cycles_per_transaction = self.block_execution_instruction_count / self.nb_transactions;
         let transactions_per_block = self.nb_transactions / self.nb_blocks;
         let gas_used_per_block = self.total_gas_used / self.nb_blocks;
         let gas_used_per_transaction = self.total_gas_used / self.nb_transactions;
@@ -33,6 +34,13 @@ impl fmt::Display for ExecutionStats {
             "| {:<30} | {:>25} |",
             "Total Instruction Count",
             self.total_instruction_count
+                .to_formatted_string(&Locale::en)
+        )?;
+        writeln!(
+            f,
+            "| {:<30} | {:>25} |",
+            "Block Execution Instruction Count",
+            self.block_execution_instruction_count
                 .to_formatted_string(&Locale::en)
         )?;
         writeln!(

--- a/zkvm-host/src/utils.rs
+++ b/zkvm-host/src/utils.rs
@@ -8,6 +8,7 @@ pub struct ExecutionStats {
     pub total_instruction_count: u64,
     pub nb_blocks: u64,
     pub nb_transactions: u64,
+    pub total_gas_used: u64,
 }
 
 impl fmt::Display for ExecutionStats {


### PR DESCRIPTION
## Overview
- Add statistics for multi-block execution that are always printed during execution.
- Increase the size of the KV store to support larger block ranges.

## Misc
The SP1 RISC-V executor degrades after 3-4B cycles (~25 blocks), we'll need to limit the span batch to that for now for the best performance.
