### PR TITLE
wip: memory freeing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,7 +5824,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "sp1-core"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -5897,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "sp1-derive"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "sp1-helper"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "cargo_metadata",
  "chrono",
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "sp1-lib"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "sp1-primitives"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "itertools 0.13.0",
  "lazy_static",
@@ -5953,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "sp1-prover"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-circuit"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "bincode",
  "itertools 0.13.0",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-compiler"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-core"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "arrayref",
  "backtrace",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-core-v2"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "arrayref",
  "backtrace",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-derive"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-gnark-ffi"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6146,7 +6146,7 @@ dependencies = [
 [[package]]
 name = "sp1-recursion-program"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -6175,7 +6175,7 @@ dependencies = [
 [[package]]
 name = "sp1-sdk"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
@@ -6218,7 +6218,7 @@ dependencies = [
 [[package]]
 name = "sp1-zkvm"
 version = "1.1.1"
-source = "git+https://github.com/succinctlabs/sp1.git?branch=experimental#7b11008d05023cadb9def590e50344cd1bbea303"
+source = "git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments#6df25ffa4db07db7a3b2d157024ce96e231056b7"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6229,7 +6229,7 @@ dependencies = [
  "rand",
  "serde",
  "sha2",
- "sp1-lib 1.1.1 (git+https://github.com/succinctlabs/sp1.git?branch=experimental)",
+ "sp1-lib 1.1.1 (git+https://github.com/succinctlabs/sp1.git?branch=ratan/memory-experiments)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,13 @@ alloy-eips = { version = "0.2", default-features = false }
 revm = { git = "https://github.com/bluealloy/revm", version = "13.0", default-features = false }
 bincode = "1.3.3"
 
-sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "experimental" }
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", branch = "experimental" }
+sp1-lib = { git = "https://github.com/succinctlabs/sp1.git", branch = "ratan/memory-experiments" }
+sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", branch = "ratan/memory-experiments" }
 # sp1-sdk = "1.1.1"
 # sp1-helper = "1.1.1"
 # Note: Using `dev` branch temporarily for the cycle-tracker-report features.
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", branch = "experimental" }
-sp1-helper = { git = "https://github.com/succinctlabs/sp1.git", branch = "experimental" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", branch = "ratan/memory-experiments" }
+sp1-helper = { git = "https://github.com/succinctlabs/sp1.git", branch = "ratan/memory-experiments" }
 
 
 # sp1

--- a/crates/client-utils/src/precompiles/mod.rs
+++ b/crates/client-utils/src/precompiles/mod.rs
@@ -86,22 +86,22 @@ macro_rules! create_hook_precompile {
     };
 }
 
-pub(crate) const ANNOTATED_SHA256: PrecompileWithAddress =
-    create_annotated_precompile!(hash::SHA256, "sha256");
-pub(crate) const ANNOTATED_RIPEMD160: PrecompileWithAddress =
-    create_annotated_precompile!(hash::RIPEMD160, "ripemd160");
-pub(crate) const ANNOTATED_IDENTITY: PrecompileWithAddress =
-    create_annotated_precompile!(identity::FUN, "identity");
+// pub(crate) const ANNOTATED_SHA256: PrecompileWithAddress =
+//     create_annotated_precompile!(hash::SHA256, "sha256");
+// pub(crate) const ANNOTATED_RIPEMD160: PrecompileWithAddress =
+//     create_annotated_precompile!(hash::RIPEMD160, "ripemd160");
+// pub(crate) const ANNOTATED_IDENTITY: PrecompileWithAddress =
+//     create_annotated_precompile!(identity::FUN, "identity");
 pub(crate) const ANNOTATED_BN_ADD: PrecompileWithAddress =
     create_hook_precompile!(bn128::add::ISTANBUL, "bn-add");
 pub(crate) const ANNOTATED_BN_MUL: PrecompileWithAddress =
     create_hook_precompile!(bn128::mul::ISTANBUL, "bn-mul");
 pub(crate) const ANNOTATED_BN_PAIR: PrecompileWithAddress =
     create_hook_precompile!(bn128::pair::ISTANBUL, "bn-pair");
-pub(crate) const ANNOTATED_MODEXP: PrecompileWithAddress =
-    create_annotated_precompile!(modexp::BERLIN, "modexp");
-pub(crate) const ANNOTATED_ECDSA_RECOVER: PrecompileWithAddress =
-    create_annotated_precompile!(secp256k1::ECRECOVER, "ecrecover");
+// pub(crate) const ANNOTATED_MODEXP: PrecompileWithAddress =
+//     create_annotated_precompile!(modexp::BERLIN, "modexp");
+// pub(crate) const ANNOTATED_ECDSA_RECOVER: PrecompileWithAddress =
+//     create_annotated_precompile!(secp256k1::ECRECOVER, "ecrecover");
 
 // TODO: When we upgrade to the latest version of revm that supports kzg-rs that compiles within SP1, we can uncomment this.
 // pub(crate) const ANNOTATED_KZG_POINT_EVAL: PrecompileWithAddress = create_annotated_precompile!(
@@ -144,18 +144,18 @@ where
                 ContextPrecompiles::new(PrecompileSpecId::from_spec_id(spec_id)).clone();
 
             // Extend with ZKVM-accelerated precompiles and annotated precompiles that track the cycle count.
-            // let override_precompiles = [
-            //     // ANNOTATED_ECDSA_RECOVER,
-            //     // ANNOTATED_SHA256,
-            //     // ANNOTATED_RIPEMD160,
-            //     // ANNOTATED_IDENTITY,
-            //     // ANNOTATED_BN_ADD,
-            //     // ANNOTATED_BN_MUL,
-            //     // ANNOTATED_BN_PAIR,
-            //     // ANNOTATED_MODEXP,
-            //     // ANNOTATED_KZG_POINT_EVAL,
-            // ];
-            // ctx_precompiles.extend(override_precompiles);
+            let override_precompiles = [
+                //     // ANNOTATED_ECDSA_RECOVER,
+                //     // ANNOTATED_SHA256,
+                //     // ANNOTATED_RIPEMD160,
+                //     // ANNOTATED_IDENTITY,
+                ANNOTATED_BN_ADD,
+                ANNOTATED_BN_MUL,
+                ANNOTATED_BN_PAIR,
+                //     // ANNOTATED_MODEXP,
+                //     // ANNOTATED_KZG_POINT_EVAL,
+            ];
+            ctx_precompiles.extend(override_precompiles);
 
             ctx_precompiles
         });

--- a/crates/client-utils/src/precompiles/mod.rs
+++ b/crates/client-utils/src/precompiles/mod.rs
@@ -144,18 +144,18 @@ where
                 ContextPrecompiles::new(PrecompileSpecId::from_spec_id(spec_id)).clone();
 
             // Extend with ZKVM-accelerated precompiles and annotated precompiles that track the cycle count.
-            let override_precompiles = [
-                ANNOTATED_ECDSA_RECOVER,
-                ANNOTATED_SHA256,
-                ANNOTATED_RIPEMD160,
-                ANNOTATED_IDENTITY,
-                ANNOTATED_BN_ADD,
-                ANNOTATED_BN_MUL,
-                ANNOTATED_BN_PAIR,
-                ANNOTATED_MODEXP,
-                // ANNOTATED_KZG_POINT_EVAL,
-            ];
-            ctx_precompiles.extend(override_precompiles);
+            // let override_precompiles = [
+            //     // ANNOTATED_ECDSA_RECOVER,
+            //     // ANNOTATED_SHA256,
+            //     // ANNOTATED_RIPEMD160,
+            //     // ANNOTATED_IDENTITY,
+            //     // ANNOTATED_BN_ADD,
+            //     // ANNOTATED_BN_MUL,
+            //     // ANNOTATED_BN_PAIR,
+            //     // ANNOTATED_MODEXP,
+            //     // ANNOTATED_KZG_POINT_EVAL,
+            // ];
+            // ctx_precompiles.extend(override_precompiles);
 
             ctx_precompiles
         });

--- a/validity-client/src/main.rs
+++ b/validity-client/src/main.rs
@@ -115,6 +115,11 @@ fn main() {
                 continue;
             }
 
+            cfg_if! {
+                if #[cfg(target_os = "zkvm")] {
+                    println!("SP1 heap pointer [1]: {:?}", sp1_zkvm::heap::SimpleAlloc::get_heap_pointer());
+                }
+            }
             for payload in l2_attrs_with_parents {
                 // Execute the payload to generate a new block header.
                 println!(
@@ -154,6 +159,11 @@ fn main() {
                 // Increment last_block_num and check if we have reached the claim block.
                 if new_block_number == boot.l2_claim_block {
                     break 'step;
+                }
+            }
+            cfg_if! {
+                if #[cfg(target_os = "zkvm")] {
+                    println!("SP1 heap pointer [2]: {:?}", sp1_zkvm::heap::SimpleAlloc::get_heap_pointer());
                 }
             }
 

--- a/validity-client/src/main.rs
+++ b/validity-client/src/main.rs
@@ -117,7 +117,8 @@ fn main() {
 
             cfg_if! {
                 if #[cfg(target_os = "zkvm")] {
-                    println!("SP1 heap pointer [1]: {:?}", sp1_zkvm::heap::SimpleAlloc::get_heap_pointer());
+                    let sp1_heap_pointer_pre_execution = sp1_zkvm::heap::SimpleAlloc::get_heap_pointer();
+                    println!("SP1 heap pointer [1]: {:?}", sp1_heap_pointer_pre_execution);
                 }
             }
             for payload in l2_attrs_with_parents {
@@ -163,7 +164,7 @@ fn main() {
             }
             cfg_if! {
                 if #[cfg(target_os = "zkvm")] {
-                    println!("SP1 heap pointer [2]: {:?}", sp1_zkvm::heap::SimpleAlloc::get_heap_pointer());
+                    println!("SP1 heap pointer [2]: {:?}", sp1_zkvm::heap::SimpleAlloc::set_heap_pointer(sp1_heap_pointer_pre_execution));
                 }
             }
 


### PR DESCRIPTION
To increase the size of the memory that can be allocated to the program, we need to either implement a more efficient allocator in SP1 or de-allocate memory specifically.